### PR TITLE
Add new schema filter to exclude nullable fields from required

### DIFF
--- a/src/Bss.Platform.Api.Documentation/DependencyInjection.cs
+++ b/src/Bss.Platform.Api.Documentation/DependencyInjection.cs
@@ -18,7 +18,8 @@ public static class DependencyInjection
         this IServiceCollection services,
         IWebHostEnvironment hostEnvironment,
         string title = "API",
-        Action<SwaggerGenOptions>? setupAction = null)
+        Action<SwaggerGenOptions>? setupAction = null,
+        bool enableExperimentalRequiredFeature = false)
     {
         if (hostEnvironment.IsProduction())
         {
@@ -32,6 +33,13 @@ public static class DependencyInjection
                    {
                        x.SwaggerDoc("api", new OpenApiInfo { Title = title });
                        x.SchemaFilter<XEnumNamesSchemaFilter>();
+                       
+                       if (enableExperimentalRequiredFeature)
+                       {
+                           x.SupportNonNullableReferenceTypes();
+                           x.NonNullableReferenceTypesAsRequired();
+                           x.SchemaFilter<ExcludeNullableFromRequiredSchemaFilter>();
+                       }
 
                        x.AddSecurityDefinition(
                            AuthorizationScheme,

--- a/src/Bss.Platform.Api.Documentation/SchemaFilters/ExcludeNullableFromRequiredSchemaFilter.cs
+++ b/src/Bss.Platform.Api.Documentation/SchemaFilters/ExcludeNullableFromRequiredSchemaFilter.cs
@@ -1,0 +1,34 @@
+using Microsoft.OpenApi.Models;
+
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Bss.Platform.Api.Documentation.SchemaFilters;
+
+/// <summary>
+///     Exclude nullable property from required.
+///     Needed for supporting correct front-end code generation by GenGen https://github.com/Luxoft/gengen
+///     Additional to https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2036
+/// </summary>
+public class ExcludeNullableFromRequiredSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (schema.Required.Count == 0)
+        {
+            return;
+        }
+
+        var nullableProperties = context.Type.GetProperties()
+            .Where(x => !x.IsNonNullableReferenceType())
+            .Select(x => x.Name);
+
+        var requiredNullableProperty = schema.Required
+            .Intersect(nullableProperties, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        foreach (var property in requiredNullableProperty)
+        {
+            schema.Required.Remove(property);
+        }
+    }
+}

--- a/src/__SolutionItems/CommonAssemblyInfo.cs
+++ b/src/__SolutionItems/CommonAssemblyInfo.cs
@@ -4,9 +4,9 @@
 [assembly: AssemblyCompany("Luxoft")]
 [assembly: AssemblyCopyright("Copyright © Luxoft 2024")]
 
-[assembly: AssemblyVersion("1.5.7.0")]
-[assembly: AssemblyFileVersion("1.5.7.0")]
-[assembly: AssemblyInformationalVersion("1.5.7.0")]
+[assembly: AssemblyVersion("1.5.8.0")]
+[assembly: AssemblyFileVersion("1.5.8.0")]
+[assembly: AssemblyInformationalVersion("1.5.8.0")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]


### PR DESCRIPTION
Swashbuckle.AspNetCore has a feature [NonNullableReferenceTypesAsRequired](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2803), but specification has required flag for nullable and non nullable properties and doesn't any difference between them.

for example dto:
```csharp
public record Dto
{
    public required Dto RequiredNonNull { get; init; }

    public required Dto? RequiredNull { get; init; }

    public Dto NonRequiredNonNull { get; init; } = null!;

    public Dto? NonRequiredNull { get; init; }
}
```

has component:
```json
{
	"Dto": {
		"required": [
			"nonRequiredNonNull",
			"requiredNonNull",
			"requiredNull"
		],
		"properties": {
			"key": {
				"type": "string"
			},
			"requiredNonNull": {
				"$ref": "#/components/schemas/Dto"
			},
			"requiredNull": {
				"$ref": "#/components/schemas/Dto"
			},
			"nonRequiredNonNull": {
				"$ref": "#/components/schemas/Dto"
			},
			"nonRequiredNull": {
				"$ref": "#/components/schemas/Dto"
			}
		},
		"additionalProperties": false
	}
}
```

and swashbuckle (openapi?) cant add nullable flag together with `$ref`, so one of the way to avoid that - exclude nullable fields from required