### PR TITLE
Extract Cloud.RoleName initialization from TelemetryDataEnrichInitializer

### DIFF
--- a/src/Bss.Platform.Kubernetes/DependencyInjection.cs
+++ b/src/Bss.Platform.Kubernetes/DependencyInjection.cs
@@ -1,4 +1,4 @@
-﻿using Bss.Platform.Kubernetes.Services;
+using Bss.Platform.Kubernetes.Services;
 
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -36,6 +36,7 @@ public static class DependencyInjection
         }
 
         services.AddSingleton<ITelemetryInitializer, TelemetryDataEnrichInitializer>();
+        services.AddSingleton<ITelemetryInitializer, CloudRoleNameTelemetryInitializer>();
 
         return services
             .AddApplicationInsightsTelemetry(configuration)

--- a/src/Bss.Platform.Kubernetes/Services/CloudRoleNameTelemetryInitializer.cs
+++ b/src/Bss.Platform.Kubernetes/Services/CloudRoleNameTelemetryInitializer.cs
@@ -1,0 +1,16 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Options;
+
+namespace Bss.Platform.Kubernetes.Services;
+
+internal class CloudRoleNameTelemetryInitializer(IOptions<KubernetesInsightsOptions> options) : ITelemetryInitializer
+{
+    public void Initialize(ITelemetry telemetry)
+    {
+        if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+        {
+            telemetry.Context.Cloud.RoleName = options.Value.RoleName;
+        }
+    }
+}

--- a/src/Bss.Platform.Kubernetes/Services/TelemetryDataEnrichInitializer.cs
+++ b/src/Bss.Platform.Kubernetes/Services/TelemetryDataEnrichInitializer.cs
@@ -1,9 +1,6 @@
-﻿using System.Reflection;
-
 using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -18,11 +15,6 @@ internal class TelemetryDataEnrichInitializer(IHttpContextAccessor accessor, IOp
             && platformContext.User.Identity?.Name is { Length: > 0 } username)
         {
             telemetry.Context.User.AuthenticatedUserId = username;
-        }
-
-        if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
-        {
-            telemetry.Context.Cloud.RoleName = options.Value.RoleName;
         }
     }
 }

--- a/src/__SolutionItems/CommonAssemblyInfo.cs
+++ b/src/__SolutionItems/CommonAssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 [assembly: AssemblyCompany("Luxoft")]
 [assembly: AssemblyCopyright("Copyright © Luxoft 2025")]
 
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
-[assembly: AssemblyInformationalVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]
+[assembly: AssemblyInformationalVersion("1.6.1.0")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]


### PR DESCRIPTION
- Separated Cloud.RoleName initialization logic to ensure it executes in all scenarios
- TelemetryDataEnrichInitializer requires HttpContext, but Cloud.RoleName must be initialized regardless of HttpContext availability
- Enables proper telemetry tracking for background jobs and RabbitMQ integration handlers